### PR TITLE
Sort drug list by name ascending

### DIFF
--- a/infra/EloquentRepository/DrugRepository.php
+++ b/infra/EloquentRepository/DrugRepository.php
@@ -64,7 +64,7 @@ class DrugRepository implements DrugRepositoryInterface
     public function getPaginator(Paginate $paginate): DrugList
     {
         $builder = DrugModel::query()
-            ->orderBy('id', OrderKey::DESC->getValue()->getRawValue())
+            ->orderBy('drug_name', 'asc')
             ->limit($paginate->getLimit()->getRawValue())
             ->offset($paginate->offset()->getRawValue());
 


### PR DESCRIPTION
## Summary
- 薬一覧APIのソート順を`id DESC`から`drug_name ASC`（薬名の昇順）に変更

## Test plan
- [ ] GET /api/drugs で薬が薬名の昇順で返却されること
- [ ] ページネーションが正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)